### PR TITLE
adding type using (sub-)headers instead of bullet lists

### DIFF
--- a/R/nested_list.R
+++ b/R/nested_list.R
@@ -1,6 +1,7 @@
 #' Output a nested list in RMarkdown list format
 #'
 #' @param x The list
+#' @param type Text to specify type of lists (unorderd, ordered, headers)
 #' @param pre Text to prefix to each line (e.g., if you want all lines indented 4 spaces to start, use "    ")
 #' @param quote Text to quote values with (e.g., use "`" to make sure values are not parsed as markdown
 #'
@@ -21,8 +22,16 @@
 #'   g = list()
 #' )
 #' nested_list(x)
-nested_list <- function(x, pre = "", quote = "") {
+#' nested_list(x, pre = "    ")
+#' nested_list(x, type = "headers", pre= "#", quote = "'")
+nested_list <- function(x, type = "unordered", pre = "", quote = "") {
   txt <- c()
+  if (type == "unordered") parameters= c("* ","    ",": ")
+  if (type == "ordered") parameters= c("1. ","    ",": ")
+  if (type == "headers") parameters= c("# ","#","\n")
+  
+  # use default if parameters not given correctly
+  if (!exists("parameters")) parameters= c("* ","    ",": ")
   
   if (is.function(x)) {
     fnc <- x %>%
@@ -45,16 +54,17 @@ nested_list <- function(x, pre = "", quote = "") {
     list_names <- names(x)
     if (is.null(list_names)) {
       bullet <- paste0(1:length(x), ". ")
+      if (type == "headers") bullet <- paste0(parameters[1], 1:length(x), "no_title", parameters[3])
     } else {
       blanks <- grep("^$", list_names)
       list_names[blanks] <- paste0("{", blanks, "}")
-      bullet <- paste0("* ", list_names, ": ")
+      bullet <- paste0(parameters[1], list_names, parameters[3])
     }
     
-    pre2 <- paste0(pre, "    ")
+    pre2 <- paste0(pre, parameters[2])
     txt <- lapply(seq_along(x), function(i) {
       item <- x[[i]]
-      sub <- nested_list(item, pre2, quote)
+      sub <- nested_list(item, type,pre2, quote)
       # add line break unless item is unnamed and length = 1
       lbreak <- ifelse(length(item) > 1 | (length(names(item)) > 0), "\n", "")
       if (grepl("\n", sub)) lbreak <- "\n"
@@ -62,7 +72,7 @@ nested_list <- function(x, pre = "", quote = "") {
     })
   }
   
-  list_txt <- paste(txt, collapse = "\n")
+  list_txt <- paste(txt, collapse = "\n\n")
   class(list_txt) <- c("nested_list", "character")
   
   list_txt

--- a/R/nested_list.R
+++ b/R/nested_list.R
@@ -54,7 +54,7 @@ nested_list <- function(x, type = "unordered", pre = "", quote = "") {
     list_names <- names(x)
     if (is.null(list_names)) {
       bullet <- paste0(1:length(x), ". ")
-      if (type == "headers") bullet <- paste0(parameters[1], 1:length(x), "no_title", parameters[3])
+      if (type == "headers") bullet <- paste0(parameters[1], 1:length(x), "_no_title", parameters[3])
     } else {
       blanks <- grep("^$", list_names)
       list_names[blanks] <- paste0("{", blanks, "}")
@@ -71,8 +71,9 @@ nested_list <- function(x, type = "unordered", pre = "", quote = "") {
       paste0(pre, bullet[i], lbreak, sub)
     })
   }
+  collapsing = ifelse (type == "headers","\n\n","\n")
   
-  list_txt <- paste(txt, collapse = "\n\n")
+  list_txt <- paste(txt, collapse = collapsing)
   class(list_txt) <- c("nested_list", "character")
   
   list_txt
@@ -88,5 +89,3 @@ nested_list <- function(x, type = "unordered", pre = "", quote = "") {
 print.nested_list <- function(x, ...) {
   cat(x)
 }
-
-

--- a/R/nested_list.R
+++ b/R/nested_list.R
@@ -24,7 +24,7 @@
 #' nested_list(x)
 #' nested_list(x, pre = "    ")
 #' nested_list(x, type = "headers", pre= "#", quote = "'")
-nested_list <- function(x, type = "unordered", pre = "", quote = "") {
+nested_list <- function(x,  pre = "", quote = "", type = "unordered") {
   txt <- c()
   if (type == "unordered") parameters= c("* ","    ",": ")
   if (type == "ordered") parameters= c("1. ","    ",": ")
@@ -64,7 +64,7 @@ nested_list <- function(x, type = "unordered", pre = "", quote = "") {
     pre2 <- paste0(pre, parameters[2])
     txt <- lapply(seq_along(x), function(i) {
       item <- x[[i]]
-      sub <- nested_list(item, type,pre2, quote)
+      sub <- nested_list(item, pre2, quote,type)
       # add line break unless item is unnamed and length = 1
       lbreak <- ifelse(length(item) > 1 | (length(names(item)) > 0), "\n", "")
       if (grepl("\n", sub)) lbreak <- "\n"

--- a/man/nested_list.Rd
+++ b/man/nested_list.Rd
@@ -4,7 +4,7 @@
 \alias{nested_list}
 \title{Output a nested list in RMarkdown list format}
 \usage{
-nested_list(x, pre = "", quote = "")
+nested_list(x, pre = "", quote = "", type = "unordered")
 }
 \arguments{
 \item{x}{The list}
@@ -12,6 +12,8 @@ nested_list(x, pre = "", quote = "")
 \item{pre}{Text to prefix to each line (e.g., if you want all lines indented 4 spaces to start, use "    ")}
 
 \item{quote}{Text to quote values with (e.g., use "`" to make sure values are not parsed as markdown}
+
+\item{type}{Text to specify type of lists (unorderd, ordered, headers)}
 }
 \value{
 A character string
@@ -33,4 +35,6 @@ x <- list(
   g = list()
 )
 nested_list(x)
+nested_list(x, pre = "    ")
+nested_list(x, type = "headers", pre= "#", quote = "'")
 }


### PR DESCRIPTION
I gave it a try, and succeeded :) not sure it is the best way to code this though ??

add a way to export as headings, default behavior not changed.
NB: may need a message if type given wrongly.

NB2: the default does order sublist elements but not first level elements, I did not change that, but may not be what people want (?). Also the ordered list way gets stange sublisting due to that.