### PR TITLE
Name optional arguments to `pivot_longer()`

### DIFF
--- a/vignettes/continuous.Rmd
+++ b/vignettes/continuous.Rmd
@@ -93,7 +93,7 @@ You have to make this sort of dataset in wide format and then manually convert i
 
 ```{r}
 long_dat <- dat %>%
-  pivot_longer(-id, "var", "value") %>%
+  pivot_longer(-id, names_to = "var", names_prefix = "value") %>%
   separate(var, c("time", "var")) %>%
   pivot_wider(names_from = var, values_from = value)
 ```


### PR DESCRIPTION
Hi there,

We ran revdeps for the upcoming release of tidyr 1.3.0 and your package came up.

In dev tidyr we have added empty `...` to the signature of `pivot_longer()` between the required and optional arguments. This allows us to more easily add new arguments in the future without breaking existing code, and forces optional arguments to be named which results in clearer user code. However, this does break your usage of `pivot_longer()` because you were supplying some of the optional arguments without naming them.

We plan to release tidyr 1.3.0 on January 23rd.

This patch is backwards compatible with CRAN tidyr. If you could go ahead and release a version of your package to CRAN with this patch, then it would help us out a lot when we release tidyr. Thanks!